### PR TITLE
Release 1.0.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           submodules: recursive
       - name: Publish to Sonatype
-        run: ./gradlew clean :android-attestation-root:android-attestation:publishToSonatype :android-attestation-root:android-attestation:closeSonatypeStagingRepository
+        run: ./gradlew clean :android-attestation:publishToSonatype :android-attestation:closeSonatypeStagingRepository
         env:
           ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.PUBLISH_SIGNING_KEYID }}
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.PUBLISH_SIGNING_KEY }}
@@ -32,7 +32,7 @@ jobs:
         with:
           submodules: recursive
       - name: Build Dokka HTML
-        run: ./gradlew :android-attestation-root:android-attestation:dokkaHtml
+        run: ./gradlew :android-attestation:dokkaHtml
       - name: Setup Pages
         uses: actions/configure-pages@v3
       - name: Upload artifact

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           submodules: recursive
       - name: Publish to Sonatype
-        run: ./gradlew clean publishToSonatype closeSonatypeStagingRepository
+        run: ./gradlew clean :android-attestation-root:android-attestation:publishToSonatype :android-attestation-root:android-attestation:closeSonatypeStagingRepository
         env:
           ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.PUBLISH_SIGNING_KEYID }}
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.PUBLISH_SIGNING_KEY }}
@@ -32,7 +32,7 @@ jobs:
         with:
           submodules: recursive
       - name: Build Dokka HTML
-        run: ./gradlew dokkaHtml
+        run: ./gradlew :android-attestation-root:android-attestation:dokkaHtml
       - name: Setup Pages
         uses: actions/configure-pages@v3
       - name: Upload artifact

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ attestation failed and the library works nicely with pure java
 - Include JavaDoc
 
 ### 0.7.4
-- More Java-freindly API
+- More Java-friendly API
 - More detailed toplevel error messages on certificate verification fail
 - Kotlin 1.8.0
 
@@ -58,3 +58,17 @@ attestation failed and the library works nicely with pure java
 ### 0.9.3
 - add guava to API for java interop
 - kotlin-stdlib API dependency for java interop
+
+
+## 1.0.0-SNAPSHOT
+
+**This version introduces incompatible changes! Re-read the readme!**
+
+Most notably, it now supports configuring multiple applications, introduces optional software-only attestation and a new hybrid
+attestation checker, which caters towards legacy devices, which originally shipped with Android 7 (Nougat).
+Most of such devices support hardware attestation only for keys, but not for app/os-related information.
+<br>
+Moreover, a builder is now available for more Java-friendliness
+
+In addition, 1.0.0. introduces a new diagnostics tool (a runnable jar), which takes an attestation certificate and prints
+out the attestation record.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,7 @@ attestation failed and the library works nicely with pure java
 - kotlin-stdlib API dependency for java interop
 
 
-## 1.0.0-SNAPSHOT
+## 1.0.0
 
 **This version introduces incompatible changes! Re-read the readme!**
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ val checker = AndroidAttestationChecker(
         appVersion = 5,                             //NULLABLE. minimum app version considered trustworthy
         androidVersion = 11000,                     //NULLABLE. minimum android version considered to be trustworthy
         patchLevel =  PatchLevel(2021, 8),          //NULLABLE. minimum patch level (year, month) considered to be trustworthy
-        requireStrongBox = false,                   //OPTIONAL, defaults to false. By default TEE security level is enough.
+        requireStrongBox = false,                   //OPTIONAL, defaults to false. By default, TEE security level is enough.
                                                     //setting this true would require keys to be created within a Titan HSM
         bootloaderUnlockAllowed = false,            //OPTIONAL, defaults to false. By default requires a locked bootloader to ensure device integrity
         ignoreLeafValidity = false,                 //OPTIONAL, defaults to false. Indicates whether to ignore the timely

--- a/README.md
+++ b/README.md
@@ -44,31 +44,85 @@ Written in Kotlin, plays nicely with Java (cf. `@JvmOverloads`), published at ma
  }
 ```
 
-The main class is `AndroidAttestationChecker`. Configuration is based on the data class `AttestationConfiguration`. Some properties are nullable – if unset, no checks against these properties are made. 
+Three flavours of attestation are implemented:
+* Hardware attestation through [HardwareAttestationChecker](https://github.com/a-sit-plus/android-attestation/blob/main/android-attestation/src/main/kotlin/AndroidAttestationChecker.kt)
+  (this is what you typically want)
+* Software attestation through [SoftwareAttestationChecker](https://github.com/a-sit-plus/android-attestation/blob/main/android-attestation/src/main/kotlin/SoftwareAttestationChecker.kt)
+  (you typically don't want to use this)
+* Nougat hybrid attestation through [NougatHybridAttestationChecker](https://github.com/a-sit-plus/android-attestation/blob/main/android-attestation/src/main/kotlin/NougatHybridAttestationChecker.kt)
+  (you may require this to support legacy devices originally shipped with Android 7 (Nougat))
+
+All of these extend [AndroidAttestationChecker](https://github.com/a-sit-plus/android-attestation/blob/main/android-attestation/src/main/kotlin/AndroidAttestationChecker.kt)
+
 
 ### Configuration
+Configuration is based on the data class `AttestationConfiguration`. Some properties are nullable – if unset, no checks against these properties are made.
+
+**Note:** In order to use anything but the `HardwareAttestationChecker` the corresponding flags need to be set in the configuration.
+This serves a dual purpose:
+1. It makes shooting yourself in the foot a lot harder (i.e. accidentally enabling software attestation or disabling
+   hardware attestation requires more manual effort).
+2. It allows for instantiating AttestationCheckers based on these flags, for example, when chaining hardware attestation
+   with nougat-style attestation as a fallback just from evaluating an `AndroidAttestationConfiguration` instance.
+
+When using Kotlin, named parameters make configuration straight-forward: 
+
 ```kotlin
-val checker = AndroidAttestationChecker(
-    AndroidAttestationConfiguration(
-        packageName = "at.asitplus.demo",           //Application package name
-        signatureDigests = someLisfOfByteArrays,    //list of fingerprint of official package signing certificates
-        appVersion = 5,                             //NULLABLE. minimum app version considered trustworthy
-        androidVersion = 11000,                     //NULLABLE. minimum android version considered to be trustworthy
-        patchLevel =  PatchLevel(2021, 8),          //NULLABLE. minimum patch level (year, month) considered to be trustworthy
-        requireStrongBox = false,                   //OPTIONAL, defaults to false. By default, TEE security level is enough.
-                                                    //setting this true would require keys to be created within a Titan HSM
-        bootloaderUnlockAllowed = false,            //OPTIONAL, defaults to false. By default requires a locked bootloader to ensure device integrity
-        ignoreLeafValidity = false,                 //OPTIONAL, defaults to false. Indicates whether to ignore the timely
-                                                    //validity of the leaf certificate (looking at you, Samsung!)
-        trustAnchors = listOf(trustedPublicKey),    //OPTIONAL, defaults to google HW attestation key. Useful for automated end-to-end tests
-        verificationSecondsOffset = 0,              //OPTIONAL, defaults to 0. Tolerance in seconds added to verification date to counter clock drift. Can be negative.
-    )
+AndroidAttestationConfiguration(
+    applications= listOf(   //REQUIRED: add applications to be attested
+        AndroidAttestationConfiguration.AppData(
+            packageName = "at.asitplus.attestation_client",
+            signatureDigests = listOf("NLl2LE1skNSEMZQMV73nMUJYsmQg7=".encodeToByteArray()),
+            appVersion = 5
+        ),
+        AndroidAttestationConfiguration.AppData( //we have a dedicated app for latest android version
+            packageName = "at.asitplus.attestation_client-tiramisu",
+            signatureDigests = listOf("NLl2LE1skNSEMZQMV73nMUJYsmQg7=".encodeToByteArray()),
+            appVersion = 2, //with a different versioning scheme
+            androidVersionOverride = 13000, //so we need to override this
+            patchLevelOverride = PatchLevel(2023, 6) //also override patch level
+        )
+    ),
+    androidVersion = 11000,                 //OPTIONAL, null by default
+    patchLevel = PatchLevel(2022, 12),      //OPTIONAL, null by default
+    requireStrongBox = false,               //OPTIONAL, defaults to false
+    allowBootloaderUnlock = false,          //OPTIONAL, defaults to false
+    requireRollbackResistance = false,      //OPTIONAL, defaults to false
+    ignoreLeafValidity = false,             //OPTIONAL, defaults to false
+    hardwareAttestationTrustAnchors = linkedSetOf(*DEFAULT_HARDWARE_TRUST_ANCHORS), //OPTIONAL, defaults  shown here
+    softwareAttestationTrustAnchors = linkedSetOf(*DEFAULT_SOFTWARE_TRUST_ANCHORS), //OPTIONAL, defaults  shown here
+    verificationSecondsOffset = -300,       //OPTIONAL, defaults to 0
+    disableHardwareAttestation = false,     //OPTIONAL, defaults to false
+    enableNougatAttestation = false,        //OPTIONAL, defaults to false
+    enableSoftwareAttestation = false       //OPTIONAL, defaults to false
 )
+```
+
+Additionally, a builder is available for smoohter java interoperability:
+
+```java
+List<AndroidAttestationConfiguration.AppData> apps = new LinkedList<>();
+
+apps.add(new AndroidAttestationConfiguration.AppData(
+        "at.asitplus.example",
+        Collections.singletonList(Base64.getDecoder().decode("NLl2LE1skNSEMZQMV73nMUJYsmQg7+Fqx/cnTw0zCtU="))
+));
+apps.add(new AndroidAttestationConfiguration.AppData(
+        "at.asitplus.anotherexample",
+        Collections.singletonList(Base64.getDecoder().decode("NLl2LE1skNSEMZQMV73nMUJYsmQg7+Fqx/cnTw0zCtU=")),
+        2
+));
+AndroidAttestationConfiguration config = new AndroidAttestationConfiguration.Builder(apps)
+        .androidVersion(11000)
+        .ingoreLeafValidity()
+        .patchLevel(new PatchLevel(2023, 03))
+        .verificationSecondsOffset(-500) //we to account for time drift
+        .build();
 ```
 
 The (nullable) properties like patch level and app version essentially allow for excluding outdated devices and obsolete app releases. If, for example a critical flaw is discovered in an attested app, users can be forced to update by considering only the latest and greatest version trustworthy and configuring the `AndroidAttestationChecker` instance accordingly.
 
-In addition, it is possible to override the function which verifies the challenge used to verify an attestation.
+In addition to configuration, it is possible to override the function which verifies the challenge used to verify an attestation when instantiating an `<*>AttestationChecker`
 By default, this is simply a `contentEquals` on the provided challenge vs a reference value.
 
 ### Obtaining an Attestation Result
@@ -78,9 +132,217 @@ By default, this is simply a `contentEquals` on the provided challenge vs a refe
 4. On the back-end a single call to `AndroidAttestationChecker.verifyAttestation()` is sufficient to remotely verify the app's integrity and establish trust in the app. This call requires the challenge from step 1.
 
 ```kotlin
-//throws an exception if attestation fails
-val atttestationRecord =  checker.verifyAttestation(attestationCertChain, Date(), challengeFromStep1)
+val checker = HardwareAttestationChecker(config)
+
+//throws an exception if attestation fails, return a ParsedAttestationRecord on success, which can be inspected
+val attestationRecord =  checker.verifyAttestation(attestationCertChain, Date(), challengeFromStep1)
 ```
+
+## Debugging
+The module [attestation-diag](https://github.com/a-sit-plus/android-attestation/blob/main/attestation-diag) contains a
+(very) simple command-line utility. It can be built using the `shadowJar` gradle task and pretty-prints attestation
+information contained in attestation certificates:
+```shell
+java -jar attestation-diag-0.0.1-all.jar "MIICkDCCAjagAwIBAgIBATAKBggqhkjOPQQDAjCBiDELMAkGA1UEBhMCVVMxEzARBgNVBAgMCkNhbGlmb3JuaWExFTATBgNVBAoMDEdvb2dsZSwgSW5jLjEQMA4GA1UECwwHQW5kcm9pZDE7MDkGA1UEAwwyQW5kcm9pZCBLZXlzdG9yZSBTb2Z0d2FyZSBBdHRlc3RhdGlvbiBJbnRlcm1lZGlhdGUwIBcNNzAwMTAxMDAwMDAwWhgPMjEwNjAyMDcwNjI4MTVaMB8xHTAbBgNVBAMMFEFuZHJvaWQgS2V5c3RvcmUgS2V5MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEoX5eWkxsJOk2z6S5tclt6bOyJhS3b+2+ULx3O3zZAwFNrbWP52YnQzp\/lsexI99lx\/Z5NRzJ9x0aD
+LdIcR\/AyqOB9jCB8zALBgNVHQ8EBAMCB4AwgcIGCisGAQQB1nkCAREEgbMwgbACAQIKAQACAQEKAQEEB2Zvb2JkYXIEADBev4U9BwIFAKtq1Vi\/hUVPBE0wSzElMCMEHmNvbS5leGFtcGxlLnRydXN0ZWRhcHBsaWNhdGlvbgIBATEiBCCI5cOT6u82gpgAtB33hqUv8KWCFYUMqKZQc4Wa3PAZDzA3oQgxBgIBAgIBA6IDAgEDowQCAgEApQgxBgIBAAIBBKoDAgEBv4N3AgUAv4U+AwIBAL+FPwIFADAfBgNVHSMEGDAWgBQ\/\/KzWGrE6noEguNUlHMVlux6RqTAKBggqhkjOPQQDAgNIADBFAiBiMBtVeUV4j1VOiRU8DnGzq9\/xtHfl0wra1xnsmxG+LAIhAJAroVhVcxxItgYZEMN1AaWqmZUXFtktQeLXh7u2F3d+"
+```
+
+The result from the above call is a pretty-printed JSON:
+```json
+{
+  "attestationVersion": 2,
+  "attestationSecurityLevel": "SOFTWARE",
+  "keymasterVersion": 1,
+  "keymasterSecurityLevel": "TRUSTED_ENVIRONMENT",
+  "attestationChallenge": "666F6F62646172",
+  "uniqueId": "",
+  "softwareEnforced": {
+    "rollbackResistance": false,
+    "noAuthRequired": false,
+    "allowWhileOnBody": false,
+    "trustedUserPresenceRequired": false,
+    "trustedConfirmationRequired": false,
+    "unlockedDeviceRequired": false,
+    "allApplications": false,
+    "creationDateTime": "1970-02-03T06:51:45.368Z",
+    "rollbackResistant": false,
+    "attestationApplicationId": {
+      "packageInfos": [
+        {
+          "packageName": "com.example.trustedapplication",
+          "version": 1
+        }
+      ],
+      "signatureDigests": [
+        "88E5C393EAEF36829800B41DF786A52FF0A58215850CA8A65073859ADCF0190F"
+      ]
+    },
+    "attestationApplicationIdBytes": "304B31253023041E636F6D2E6578616D706C652E747275737465646170706C69636174696F6E0201013122042088E5C393EAEF36829800B41DF786A52FF0A58215850CA8A65073859ADCF0190F",
+    "individualAttestation": false,
+    "identityCredentialKey": false
+  },
+  "teeEnforced": {
+    "purpose": [
+      "SIGN",
+      "VERIFY"
+    ],
+    "algorithm": "EC",
+    "keySize": 256,
+    "digest": [
+      "NONE",
+      "SHA_2_256"
+    ],
+    "ecCurve": "P_256",
+    "rollbackResistance": false,
+    "noAuthRequired": true,
+    "allowWhileOnBody": false,
+    "trustedUserPresenceRequired": false,
+    "trustedConfirmationRequired": false,
+    "unlockedDeviceRequired": false,
+    "allApplications": false,
+    "origin": "GENERATED",
+    "rollbackResistant": true,
+    "individualAttestation": false,
+    "identityCredentialKey": false
+  },
+  "attestedKey": {
+    "algorithm": "EC",
+    "format": "X.509",
+    "encoded": "3059301306072A8648CE3D020106082A8648CE3D03010703420004A17E5E5A4C6C24E936CFA4B9B5C96DE9B3B22614B76FEDBE50BC773B7CD903014DADB58FE76627433A7F96C7B123DF65C7F679351CC9F71D1A0CB748711FC0CA"
+  }
+}
+
+```
+
+Nulls and empty arrays are omitted by default, but can be printed by adding `-v` at the end of the command line.
+The example below shows a verbose JSON obtained this way:
+```json
+{
+  "attestationVersion": 2,
+  "attestationSecurityLevel": "SOFTWARE",
+  "keymasterVersion": 1,
+  "keymasterSecurityLevel": "TRUSTED_ENVIRONMENT",
+  "attestationChallenge": "666F6F62646172",
+  "uniqueId": "",
+  "softwareEnforced": {
+    "purpose": [],
+    "algorithm": null,
+    "keySize": null,
+    "digest": [],
+    "padding": [],
+    "ecCurve": null,
+    "rsaPublicExponent": null,
+    "rollbackResistance": false,
+    "activeDateTime": null,
+    "originationExpireDateTime": null,
+    "usageExpireDateTime": null,
+    "noAuthRequired": false,
+    "userAuthType": [],
+    "authTimeout": null,
+    "allowWhileOnBody": false,
+    "trustedUserPresenceRequired": false,
+    "trustedConfirmationRequired": false,
+    "unlockedDeviceRequired": false,
+    "allApplications": false,
+    "applicationId": null,
+    "creationDateTime": "1970-02-03T06:51:45.368Z",
+    "origin": null,
+    "rollbackResistant": false,
+    "rootOfTrust": null,
+    "osVersion": null,
+    "osPatchLevel": null,
+    "attestationApplicationId": {
+      "packageInfos": [
+        {
+          "packageName": "com.example.trustedapplication",
+          "version": 1
+        }
+      ],
+      "signatureDigests": [
+        "88E5C393EAEF36829800B41DF786A52FF0A58215850CA8A65073859ADCF0190F"
+      ]
+    },
+    "attestationApplicationIdBytes": "304B31253023041E636F6D2E6578616D706C652E747275737465646170706C69636174696F6E0201013122042088E5C393EAEF36829800B41DF786A52FF0A58215850CA8A65073859ADCF0190F",
+    "attestationIdBrand": null,
+    "attestationIdDevice": null,
+    "attestationIdProduct": null,
+    "attestationIdSerial": null,
+    "attestationIdImei": null,
+    "attestationIdSecondImei": null,
+    "attestationIdMeid": null,
+    "attestationIdManufacturer": null,
+    "attestationIdModel": null,
+    "vendorPatchLevel": null,
+    "bootPatchLevel": null,
+    "individualAttestation": false,
+    "identityCredentialKey": false
+  },
+  "teeEnforced": {
+    "purpose": [
+      "SIGN",
+      "VERIFY"
+    ],
+    "algorithm": "EC",
+    "keySize": 256,
+    "digest": [
+      "NONE",
+      "SHA_2_256"
+    ],
+    "padding": [],
+    "ecCurve": "P_256",
+    "rsaPublicExponent": null,
+    "rollbackResistance": false,
+    "activeDateTime": null,
+    "originationExpireDateTime": null,
+    "usageExpireDateTime": null,
+    "noAuthRequired": true,
+    "userAuthType": [],
+    "authTimeout": null,
+    "allowWhileOnBody": false,
+    "trustedUserPresenceRequired": false,
+    "trustedConfirmationRequired": false,
+    "unlockedDeviceRequired": false,
+    "allApplications": false,
+    "applicationId": null,
+    "creationDateTime": null,
+    "origin": "GENERATED",
+    "rollbackResistant": true,
+    "rootOfTrust": null,
+    "osVersion": null,
+    "osPatchLevel": null,
+    "attestationApplicationId": null,
+    "attestationApplicationIdBytes": null,
+    "attestationIdBrand": null,
+    "attestationIdDevice": null,
+    "attestationIdProduct": null,
+    "attestationIdSerial": null,
+    "attestationIdImei": null,
+    "attestationIdSecondImei": null,
+    "attestationIdMeid": null,
+    "attestationIdManufacturer": null,
+    "attestationIdModel": null,
+    "vendorPatchLevel": null,
+    "bootPatchLevel": null,
+    "individualAttestation": false,
+    "identityCredentialKey": false
+  },
+  "attestedKey": {
+    "algorithm": "EC",
+    "format": "X.509",
+    "encoded": "3059301306072A8648CE3D020106082A8648CE3D03010703420004A17E5E5A4C6C24E936CFA4B9B5C96DE9B3B22614B76FEDBE50BC773B7CD903014DADB58FE76627433A7F96C7B123DF65C7F679351CC9F71D1A0CB748711FC0CA"
+  }
+}
+```
+
+Attestation certificates can also be read from a file (need to be PEM-encoded, but can also be plain base64 MIME-encoded):
+```shell
+java -jar attestation-diag-0.0.1-all.jar -f cert.pem
+```
+
+(Some) illegal characters are stripped from the base64 input for convenience, which means that dirty base64 also somewhat works.
+
+**Note:** Pretty-printing is done using Gson (in order to leave the upstream code untouched), which also means that it relies
+on reflective access to platform types. Hence, this jar will only run on the same Java version it was built with!
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Android Key Attestation Library
+# Android  Attestation Library
 [![GitHub license](https://img.shields.io/badge/license-Apache%20License%202.0-brightgreen.svg?style=flat)](http://www.apache.org/licenses/LICENSE-2.0) 
 [![Kotlin](https://img.shields.io/badge/kotlin-1.9.10-blue.svg?logo=kotlin)](http://kotlinlang.org)
 ![Java](https://img.shields.io/badge/java-11-blue.svg?logo=OPENJDK)

--- a/android-attestation/build.gradle.kts
+++ b/android-attestation/build.gradle.kts
@@ -48,7 +48,8 @@ dependencies {
     api("com.google.guava:guava:32.1.2-jre")
     api(kotlin("stdlib"))
     implementation("org.jspecify:jspecify:0.2.0")
-    implementation("com.google.code.gson:gson:2.10.1")
+
+    testImplementation("org.slf4j:slf4j-reload4j:1.7.36")
 }
 
 

--- a/android-attestation/build.gradle.kts
+++ b/android-attestation/build.gradle.kts
@@ -3,7 +3,7 @@ import at.asitplus.gradle.ktor
 import org.gradle.kotlin.dsl.support.listFilesOrdered
 
 group = "at.asitplus"
-version = "0.9.3"
+version = "1.0.0"
 
 plugins {
     kotlin("jvm")

--- a/android-attestation/build.gradle.kts
+++ b/android-attestation/build.gradle.kts
@@ -48,6 +48,7 @@ dependencies {
     api("com.google.guava:guava:32.1.2-jre")
     api(kotlin("stdlib"))
     implementation("org.jspecify:jspecify:0.2.0")
+    implementation("com.google.code.gson:gson:2.10.1")
 }
 
 

--- a/android-attestation/src/main/kotlin/AndroidAttestationChecker.kt
+++ b/android-attestation/src/main/kotlin/AndroidAttestationChecker.kt
@@ -139,7 +139,7 @@ abstract class AndroidAttestationChecker(
 
     @Throws(AttestationException::class)
     protected fun AuthorizationList.verifySystemLocked() {
-        if (attestationConfiguration.bootloaderUnlockAllowed) return
+        if (attestationConfiguration.allowBootloaderUnlock) return
 
         if (rootOfTrust == null) throw AttestationException("Root of Trust not present")
 

--- a/android-attestation/src/main/kotlin/AndroidAttestationConfiguration.kt
+++ b/android-attestation/src/main/kotlin/AndroidAttestationConfiguration.kt
@@ -17,6 +17,31 @@ data class PatchLevel(val year: Int, val month: Int) {
 }
 
 /**
+ * Default trust anchors used to verify hardware attestation
+ */
+val DEFAULT_HARDWARE_TRUST_ANCHORS = arrayOf(
+    KeyFactory.getInstance("RSA")
+        .generatePublic(X509EncodedKeySpec(Base64.getDecoder().decode(GOOGLE_ROOT_CA_PUB_KEY)))
+)
+
+
+/**
+ * Default trust anchors used to verify software attestation
+ */
+val DEFAULT_SOFTWARE_TRUST_ANCHORS = arrayOf(
+    KeyFactory.getInstance("EC")
+        .generatePublic(
+            X509EncodedKeySpec(Base64.getDecoder().decode(SoftwareAttestationChecker.GOOGLE_SOFTWARE_EC_ROOT))
+        ),
+    KeyFactory.getInstance("RSA")
+        .generatePublic(
+            X509EncodedKeySpec(
+                Base64.getDecoder().decode(SoftwareAttestationChecker.GOOGLE_SOFTWARE_RSA_ROOT)
+            )
+        )
+)
+
+/**
  * Main Android Key attestation configuration class serving as ground truth for all key attestation verifications.
  *
  * @param packageNames Android app package name (e.g. `at.asitplus.demo`)
@@ -39,28 +64,34 @@ data class PatchLevel(val year: Int, val month: Int) {
 
 class AndroidAttestationConfiguration @JvmOverloads constructor(
 
-
+    /**
+     * List of applications, which can be attested
+     */
     val applications: List<AppData>,
 
     /**
      * optional parameter. If set, attestation enforces Android version to be greater or equal to this parameter.
      * **Caution:** Major Android versions increment in steps of thousands. I.e. Android 11 is specified as `11000`
+     * Can be overridden for individual apps
      */
     val androidVersion: Int? = null,
 
     /**
      * optional parameter. If set, attestation enforces Security patch level to be greater or equal to this parameter.
+     * Can be overridden for individual apps.
      */
     patchLevel: PatchLevel? = null,
 
     /**
-     * Set to `true` if *StrongBox* security level should be required
+     * Set to `true` if *StrongBox* security level should be required.
+     * **BEWARE** that this switch is utterly useless if [NougatHybridAttestationChecker] of [SoftwareAttestationChecker] is used
      */
     val requireStrongBox: Boolean = false,
 
     /**
      * Set to true if unlocked bootloaders should be allowed. **Attention:** Allowing unlocked bootloaders in production
      * effectively defeats the purpose of Key Attestation. Useful for debugging/testing
+     * **BEWARE** that this switch is utterly useless if [NougatHybridAttestationChecker] of [SoftwareAttestationChecker] is used
      */
     val bootloaderUnlockAllowed: Boolean = false,
 
@@ -77,42 +108,56 @@ class AndroidAttestationConfiguration @JvmOverloads constructor(
     /**
      * Manually specify the trust anchor for HW-attested certificate chains. Defaults to google HW attestation key.
      * Overriding this list is useful for automated end-to-end tests, for example.
+     * The default trust anchors are accessible through [DEFAULT_HARDWARE_TRUST_ANCHORS]
      */
-    val hardwareAttestationTrustAnchors: List<PublicKey> = listOf(
-        KeyFactory.getInstance("RSA")
-            .generatePublic(X509EncodedKeySpec(Base64.getDecoder().decode(GOOGLE_ROOT_CA_PUB_KEY)))
-    ),
+    val hardwareAttestationTrustAnchors: Set<PublicKey> = linkedSetOf(*DEFAULT_HARDWARE_TRUST_ANCHORS),
 
     /**
      * Manually specify the trust anchor for HW-attested certificate chains. Defaults to google HW attestation key.
      * Overriding this list is useful for automated end-to-end tests, for example.
+     * The default trust anchors are accessible through [DEFAULT_SOFTWARE_TRUST_ANCHORS]
      */
-    val softwareAttestationTrustAnchors: List<PublicKey> = listOf(
-        KeyFactory.getInstance("EC")
-            .generatePublic(
-                X509EncodedKeySpec(Base64.getDecoder().decode(SoftwareAttestationChecker.GOOGLE_SOFTWARE_EC_ROOT))
-            ),
-        KeyFactory.getInstance("RSA")
-            .generatePublic(
-                X509EncodedKeySpec(
-                    Base64.getDecoder().decode(SoftwareAttestationChecker.GOOGLE_SOFTWARE_RSA_ROOT)
-                )
-            )
-    ),
+    val softwareAttestationTrustAnchors: Set<PublicKey> = linkedSetOf(*DEFAULT_SOFTWARE_TRUST_ANCHORS),
 
     /**
      *  Tolerance in seconds added to verification date
-     *
      */
-    val verificationSecondsOffset: Int = 0
-) {
+    val verificationSecondsOffset: Int = 0,
+
+    /**
+     * Entirely disable creation of a [HardwareAttestationChecker]. Only change this flag, if you **really** know what
+     * you are doing!
+     * @see enableSoftwareAttestation
+     */
+    val disableHardwareAttestation: Boolean = false,
+
+    /**
+     * Enables hybrid attestation. A [NougatHybridAttestationChecker] can only be instantiated if this flag is set to true.
+     * Only change this flag, if you requre support for devices, which originally shipped with Android 7 (Nougat), as these
+     * devices only support hardware-backed key attestation, but provide no indication about the OS state.
+     * Hence, app-attestation cannot be trusted, but key attestation can.
+     */
+    val enableNougatAttestation: Boolean = false,
+
+    /**
+     * Enables software attestation. A [SoftwareAttestationChecker] can only be instantiated if this flag is set to true.
+     * Only change this flag, if you **really** know what you are doing!
+     * Enabling this flag, while keeping [disableHardwareAttestation] `true` makes is possible to instantiate both a
+     * [HardwareAttestationChecker] and a [SoftwareAttestationChecker].
+     */
+    val enableSoftwareAttestation: Boolean = false,
+
+    ) {
 
     /**
      * Internal representation of the patch level as contained in the [com.google.android.attestation.ParsedAttestationRecord]
      */
     val osPatchLevel: Int? = patchLevel?.asSingleInt
 
-    class AppData(
+    /**
+     * Specifies a to-be attested app
+     */
+    class AppData @JvmOverloads constructor(
         /**
          * Android app package name (e.g. `at.asitplus.demo`)
          */
@@ -128,10 +173,28 @@ class AndroidAttestationConfiguration @JvmOverloads constructor(
          * optional parameter. If set, attestation enforces application version to be greater or equal to this parameter
          */
         val appVersion: Int? = null,
-    ) {
+
+        /**
+         * optional parameter. If set, attestation enforces Android version to be greater or equal to this parameter.
+         * **Caution:** Major Android versions increment in steps of thousands. I.e. Android 11 is specified as `11000`
+         */
+        val androidVersionOverride: Int? = null,
+
+        /**
+         * optional parameter. If set, attestation enforces Security patch level to be greater or equal to this parameter.
+         */
+        patchLevelOverride: PatchLevel? = null,
+
+        ) {
         init {
             if (signatureDigests.isEmpty()) throw AttestationException("No signature digests specified")
         }
+
+        /**
+         * Internal representation of the patch level as contained in the [com.google.android.attestation.ParsedAttestationRecord]
+         */
+        val osPatchLevel: Int? = patchLevelOverride?.asSingleInt
+
     }
 
     init {
@@ -139,5 +202,125 @@ class AndroidAttestationConfiguration @JvmOverloads constructor(
             "No trust anchors configured"
         )
         if (applications.isEmpty()) throw AttestationException("No apps configured")
+    }
+
+    /**
+     * Builder to construct an [AndroidAttestationConfiguration] in a java-friendly way
+     * @param applications applications to be attested
+     */
+    class Builder(private val applications: List<AppData>) {
+
+        /**
+         * convenience constructor to attest a [singleApp]
+         */
+        constructor(singleApp: AppData) : this(listOf(singleApp))
+
+        private var androidVersion: Int? = null
+        private var patchLevel: PatchLevel? = null
+        private var requireStrongBox: Boolean = false
+        private var bootloaderUnlockAllowed: Boolean = false
+        private var rollbackResitanceRequired: Boolean = false
+        private var ignoreLeafValidity: Boolean = false
+        private var hardwareAttestationTrustAnchors = mutableSetOf(*DEFAULT_HARDWARE_TRUST_ANCHORS)
+
+        private var softwareAttestationTrustAnchors = mutableSetOf(*DEFAULT_SOFTWARE_TRUST_ANCHORS)
+
+        private var verificationSecondsOffset = 0
+
+        private var disableHwAttestation: Boolean = false
+        private var enableSwAttestation: Boolean = false
+        private var enableNougatAttestation: Boolean = false
+
+        /**
+         * specifies a minimum Android version
+         * @see AndroidAttestationConfiguration.androidVersion
+         */
+        fun androidVersion(version: Int) = apply { androidVersion = version }
+
+        /**
+         * @see PatchLevel
+         */
+        fun patchLevel(lvl: PatchLevel) = apply { patchLevel = lvl }
+
+        /**
+         * @see AndroidAttestationConfiguration.requireStrongBox
+         */
+        fun requireStrongBox() = apply { requireStrongBox = true }
+
+        /**
+         * @see AndroidAttestationConfiguration.bootloaderUnlockAllowed
+         */
+        fun allowBootloaderUnlock() = apply { bootloaderUnlockAllowed = true }
+
+        /**
+         * @see AndroidAttestationConfiguration.requireRollbackResistance
+         */
+        fun requireRollbackResistance() = apply { rollbackResitanceRequired = true }
+
+        /**
+         * @see AndroidAttestationConfiguration.ignoreLeafValidity
+         */
+        fun ingoreLeafValidity() = apply { ignoreLeafValidity = true }
+
+        /**
+         * @see AndroidAttestationConfiguration.hardwareAttestationTrustAnchors
+         */
+        fun hardwareAttestationTrustAnchors(anchors: Set<PublicKey>) =
+            apply { hardwareAttestationTrustAnchors.apply { clear(); addAll(anchors) } }
+
+        /**
+         * adds a single hardware attestation trust anchor
+         * @see AndroidAttestationConfiguration.hardwareAttestationTrustAnchors
+         */
+        fun addHardwareAttestationTurstAnchor(anchor: PublicKey) = apply { hardwareAttestationTrustAnchors += anchor }
+
+        /**
+         * @see AndroidAttestationConfiguration.softwareAttestationTrustAnchors
+         */
+        fun softwareAttestationTrustAnchors(anchors: Set<PublicKey>) =
+            apply { softwareAttestationTrustAnchors.apply { clear(); addAll(anchors) } }
+
+        /**
+         * adds a single software attestation trust anchor
+         * @see AndroidAttestationConfiguration.softwareAttestationTrustAnchors
+         */
+        fun addSoftwareAttestationTrustAnchor(anchor: PublicKey) = apply { softwareAttestationTrustAnchors += anchor }
+
+        /**
+         * @see AndroidAttestationConfiguration.verificationSecondsOffset
+         */
+        fun verificationSecondsOffset(seconds: Int) = apply { verificationSecondsOffset = seconds }
+
+        /**
+         * @see AndroidAttestationConfiguration.disableHardwareAttestation
+         */
+        fun disableHardwareAttestation() = apply { disableHwAttestation = true }
+
+        /**
+         * @see AndroidAttestationConfiguration.enableSoftwareAttestation
+         */
+        fun enableSoftwareAttestation() = apply { enableSwAttestation = true }
+
+        /**
+         * @see AndroidAttestationConfiguration.enableNougatAttestation
+         */
+        fun enableNougatAttestation() = apply { enableNougatAttestation = true }
+
+        fun build() = AndroidAttestationConfiguration(
+            applications = applications,
+            androidVersion = androidVersion,
+            patchLevel = patchLevel,
+            requireStrongBox = requireStrongBox,
+            bootloaderUnlockAllowed = bootloaderUnlockAllowed,
+            requireRollbackResistance = rollbackResitanceRequired,
+            ignoreLeafValidity = ignoreLeafValidity,
+            hardwareAttestationTrustAnchors = hardwareAttestationTrustAnchors,
+            softwareAttestationTrustAnchors = softwareAttestationTrustAnchors,
+            verificationSecondsOffset = verificationSecondsOffset,
+            disableHardwareAttestation = disableHwAttestation,
+            enableSoftwareAttestation = enableSwAttestation,
+            enableNougatAttestation = enableNougatAttestation
+        )
+
     }
 }

--- a/android-attestation/src/main/kotlin/AndroidAttestationConfiguration.kt
+++ b/android-attestation/src/main/kotlin/AndroidAttestationConfiguration.kt
@@ -198,10 +198,12 @@ class AndroidAttestationConfiguration @JvmOverloads constructor(
     }
 
     init {
-        if (hardwareAttestationTrustAnchors.isEmpty() && softwareAttestationTrustAnchors.isEmpty()) throw AttestationException(
-            "No trust anchors configured"
-        )
+        if (hardwareAttestationTrustAnchors.isEmpty() && softwareAttestationTrustAnchors.isEmpty())
+            throw AttestationException("No trust anchors configured")
+
         if (applications.isEmpty()) throw AttestationException("No apps configured")
+        if (disableHardwareAttestation && !enableSoftwareAttestation && !enableNougatAttestation)
+            throw AttestationException("Neither hardware, nor hybrid, nor software attestation enabled")
     }
 
     /**

--- a/android-attestation/src/main/kotlin/AndroidAttestationConfiguration.kt
+++ b/android-attestation/src/main/kotlin/AndroidAttestationConfiguration.kt
@@ -42,26 +42,40 @@ val DEFAULT_SOFTWARE_TRUST_ANCHORS = arrayOf(
 )
 
 /**
- * Main Android Key attestation configuration class serving as ground truth for all key attestation verifications.
+ * Main Android attestation configuration class serving as ground truth for all key and app attestation verifications.
  *
- * @param packageNames Android app package name (e.g. `at.asitplus.demo`)
- * @param signatureDigests SHA-256 digests of signature certificates used to sign the APK. This is a Google cloud signing
- * certificate for production play store releases. Being able to specify multiple digests makes it easy to use development
- * builds and production builds in parallel.
- * @param appVersion optional parameter. If set, attestation enforces application version to be greater or equal to this parameter
+ * @param applications list of applications to be attested
+ * @param androidVersion optional parameter. If set, attestation enforces Android version to be greater or equal to this parameter.
+ * **Caution:** Major Android versions increment in steps of thousands. I.e. Android 11 is specified as `11000`
+ * Can be overridden for individual apps
  * @param patchLevel optional parameter. If set, attestation enforces Security patch level to be greater or equal to this parameter
- * @param requireStrongBox Set to `true` if *StrongBox* security level should be required
- * @param bootloaderUnlockAllowed Set to true if unlocked bootloaders should be allowed.
- * **Attention:** Allowing unlocked bootloaders in production effectively defeats the purpose of Key Attestation.
+ * @param requireStrongBox optional parameter. Set to `true` if *StrongBox* security level should be required
+ * @param allowBootloaderUnlock optional parameter. Set to true if unlocked bootloaders should be allowed.
+ * **Attention:** Allowing unlocked bootloaders in production effectively defeats the purpose of app attestation.
+ * (but retains the ability to attest whether a key is securely stored in hardware)
  * Useful for debugging/testing
- * @param requireRollbackResistance Unsupported by most devices.
+ * @param requireRollbackResistance optional parameter. Unsupported by most devices.
  * See [Official Documentation](https://source.android.com/docs/security/features/keystore/implementer-ref#rollback_resistance)
- * @param ignoreLeafValidity Whether to ignore the timely validity of the leaf certificate (looking at you, Samsung!)
- * @param hardwareAttestationTrustAnchors Manually specify the trust anchor for HW-attested certificate chains. Defaults to google HW attestation key.
- * Overriding this list is useful for automated end-to-end tests, for example.
- *
+ * @param ignoreLeafValidity optional parameter. Whether to ignore the timely validity of the leaf certificate (looking at you, Samsung!)
+ * @param hardwareAttestationTrustAnchors Manually specify the trust anchor for HW-attested certificate chains.
+ * Defaults to google HW attestation key. Overriding this set is useful for automated end-to-end tests, for example.
+ * The default trust anchors are accessible through [DEFAULT_HARDWARE_TRUST_ANCHORS]
+ * @param softwareAttestationTrustAnchors Manually specify the trust anchor for SW-attested certificate chains.
+ * Defaults to google SW attestation keys. Overriding this set is useful for automated end-to-end tests, for example.
+ * The default trust anchors are accessible through [DEFAULT_SOFTWARE_TRUST_ANCHORS]
+ * @param disableHardwareAttestation Entirely disable creation of a [HardwareAttestationChecker].
+ * Only change this flag, if you **really** know what you are doing!
+ * @param enableNougatAttestation Enables hybrid attestation.
+ * [NougatHybridAttestationChecker] can only be instantiated if this flag is set to true.
+ * Only change this flag, if you require support for devices, which originally shipped with Android 7 (Nougat), as these
+ * devices only support hardware-backed key attestation, but provide no indication about the OS state.
+ * Hence, app-attestation cannot be trusted, but key attestation still can.
+ * @param enableSoftwareAttestation Enables software attestation.
+ * A [SoftwareAttestationChecker] can only be instantiated if this flag is set to true.
+ * Only change this flag, if you **really** know what you are doing!
+ * Enabling this flag, while keeping [disableHardwareAttestation] `true` makes is possible to instantiate both a
+ * [HardwareAttestationChecker] and a [SoftwareAttestationChecker].
  */
-
 class AndroidAttestationConfiguration @JvmOverloads constructor(
 
     /**
@@ -93,7 +107,7 @@ class AndroidAttestationConfiguration @JvmOverloads constructor(
      * effectively defeats the purpose of Key Attestation. Useful for debugging/testing
      * **BEWARE** that this switch is utterly useless if [NougatHybridAttestationChecker] of [SoftwareAttestationChecker] is used
      */
-    val bootloaderUnlockAllowed: Boolean = false,
+    val allowBootloaderUnlock: Boolean = false,
 
     /**
      * Unsupported by most devices. See [Official Documentation](https://source.android.com/docs/security/features/keystore/implementer-ref#rollback_resistance)
@@ -107,14 +121,14 @@ class AndroidAttestationConfiguration @JvmOverloads constructor(
 
     /**
      * Manually specify the trust anchor for HW-attested certificate chains. Defaults to google HW attestation key.
-     * Overriding this list is useful for automated end-to-end tests, for example.
+     * Overriding this set is useful for automated end-to-end tests, for example.
      * The default trust anchors are accessible through [DEFAULT_HARDWARE_TRUST_ANCHORS]
      */
     val hardwareAttestationTrustAnchors: Set<PublicKey> = linkedSetOf(*DEFAULT_HARDWARE_TRUST_ANCHORS),
 
     /**
-     * Manually specify the trust anchor for HW-attested certificate chains. Defaults to google HW attestation key.
-     * Overriding this list is useful for automated end-to-end tests, for example.
+     * Manually specify the trust anchor for SW-attested certificate chains. Defaults to google SW attestation keys.
+     * Overriding this set is useful for automated end-to-end tests, for example.
      * The default trust anchors are accessible through [DEFAULT_SOFTWARE_TRUST_ANCHORS]
      */
     val softwareAttestationTrustAnchors: Set<PublicKey> = linkedSetOf(*DEFAULT_SOFTWARE_TRUST_ANCHORS),
@@ -133,9 +147,9 @@ class AndroidAttestationConfiguration @JvmOverloads constructor(
 
     /**
      * Enables hybrid attestation. A [NougatHybridAttestationChecker] can only be instantiated if this flag is set to true.
-     * Only change this flag, if you requre support for devices, which originally shipped with Android 7 (Nougat), as these
+     * Only change this flag, if you require support for devices, which originally shipped with Android 7 (Nougat), as these
      * devices only support hardware-backed key attestation, but provide no indication about the OS state.
-     * Hence, app-attestation cannot be trusted, but key attestation can.
+     * Hence, app-attestation cannot be trusted, but key attestation still can.
      */
     val enableNougatAttestation: Boolean = false,
 
@@ -150,13 +164,52 @@ class AndroidAttestationConfiguration @JvmOverloads constructor(
     ) {
 
     /**
+     * Convenience constructor to attest a single app1
+     */
+    constructor(
+        singleApp: AppData,
+        androidVersion: Int? = null,
+        patchLevel: PatchLevel? = null,
+        requireStrongBox: Boolean = false,
+        allowBootloaderUnlock: Boolean = false,
+        requireRollbackResistance: Boolean = false,
+        ignoreLeafValidity: Boolean = false,
+        hardwareAttestationTrustAnchors: Set<PublicKey> = linkedSetOf(*DEFAULT_HARDWARE_TRUST_ANCHORS),
+        softwareAttestationTrustAnchors: Set<PublicKey> = linkedSetOf(*DEFAULT_SOFTWARE_TRUST_ANCHORS),
+        verificationSecondsOffset: Int = 0,
+        disableHardwareAttestation: Boolean = false,
+        enableNougatAttestation: Boolean = false,
+        enableSoftwareAttestation: Boolean = false
+    ) : this(
+        listOf(singleApp),
+        androidVersion = androidVersion,
+        patchLevel = patchLevel,
+        requireStrongBox = requireStrongBox,
+        allowBootloaderUnlock = allowBootloaderUnlock,
+        requireRollbackResistance = requireRollbackResistance,
+        ignoreLeafValidity = ignoreLeafValidity,
+        hardwareAttestationTrustAnchors = hardwareAttestationTrustAnchors,
+        softwareAttestationTrustAnchors = softwareAttestationTrustAnchors,
+        verificationSecondsOffset = verificationSecondsOffset,
+        disableHardwareAttestation = disableHardwareAttestation,
+        enableNougatAttestation = enableNougatAttestation,
+        enableSoftwareAttestation = enableSoftwareAttestation
+    )
+
+    /**
      * Internal representation of the patch level as contained in the [com.google.android.attestation.ParsedAttestationRecord]
      */
     val osPatchLevel: Int? = patchLevel?.asSingleInt
 
     /**
      * Specifies a to-be attested app
-     */
+     *
+     * @param packageName Android app package name (e.g. `at.asitplus.demo`)
+     * @param signatureDigests SHA-256 digests of signature certificates used to sign the APK. This is a Google cloud signing
+     * certificate for production play store releases. Being able to specify multiple digests makes it easy to use development
+     * builds and production builds in parallel.
+     * @param appVersion optional parameter. If set, attestation enforces application version to be greater or equal to this parameter
+     * */
     class AppData @JvmOverloads constructor(
         /**
          * Android app package name (e.g. `at.asitplus.demo`)
@@ -250,7 +303,7 @@ class AndroidAttestationConfiguration @JvmOverloads constructor(
         fun requireStrongBox() = apply { requireStrongBox = true }
 
         /**
-         * @see AndroidAttestationConfiguration.bootloaderUnlockAllowed
+         * @see AndroidAttestationConfiguration.allowBootloaderUnlock
          */
         fun allowBootloaderUnlock() = apply { bootloaderUnlockAllowed = true }
 
@@ -313,7 +366,7 @@ class AndroidAttestationConfiguration @JvmOverloads constructor(
             androidVersion = androidVersion,
             patchLevel = patchLevel,
             requireStrongBox = requireStrongBox,
-            bootloaderUnlockAllowed = bootloaderUnlockAllowed,
+            allowBootloaderUnlock = bootloaderUnlockAllowed,
             requireRollbackResistance = rollbackResitanceRequired,
             ignoreLeafValidity = ignoreLeafValidity,
             hardwareAttestationTrustAnchors = hardwareAttestationTrustAnchors,

--- a/android-attestation/src/main/kotlin/HardwareAttestationChecker.kt
+++ b/android-attestation/src/main/kotlin/HardwareAttestationChecker.kt
@@ -1,0 +1,50 @@
+package at.asitplus.attestation.android
+
+import at.asitplus.attestation.android.exceptions.AttestationException
+import com.google.android.attestation.ParsedAttestationRecord
+import io.ktor.client.*
+import io.ktor.client.call.*
+import io.ktor.client.engine.*
+import io.ktor.client.engine.cio.*
+import io.ktor.client.plugins.cache.*
+import io.ktor.client.plugins.contentnegotiation.*
+import io.ktor.client.request.*
+import io.ktor.serialization.kotlinx.json.*
+import java.util.*
+
+class HardwareAttestationChecker @JvmOverloads constructor(
+    attestationConfiguration: AndroidAttestationConfiguration,
+    verifyChallenge: (expected: ByteArray, actual: ByteArray) -> Boolean = { expected, actual -> expected contentEquals actual }
+) : AndroidAttestationChecker(attestationConfiguration, verifyChallenge) {
+
+    init {
+        if (attestationConfiguration.hardwareAttestationTrustAnchors.isEmpty()) throw AttestationException("No hardware attestation trust anchors configured")
+    }
+
+    @Throws(AttestationException::class)
+    override fun ParsedAttestationRecord.verifySecurityLevel() {
+        if (attestationConfiguration.requireStrongBox) {
+            if (attestationSecurityLevel != ParsedAttestationRecord.SecurityLevel.STRONG_BOX)
+                throw AttestationException("Attestation security level not StrongBox")
+            if (keymasterSecurityLevel != ParsedAttestationRecord.SecurityLevel.STRONG_BOX)
+                throw AttestationException("Keymaster security level not StrongBox")
+        } else {
+            if (attestationSecurityLevel == ParsedAttestationRecord.SecurityLevel.SOFTWARE)
+                throw AttestationException("Attestation security level software")
+            if (keymasterSecurityLevel == ParsedAttestationRecord.SecurityLevel.SOFTWARE)
+                throw AttestationException("Keymaster security level software")
+        }
+
+    }
+
+    override val trustAnchors = attestationConfiguration.hardwareAttestationTrustAnchors
+
+    @Throws(AttestationException::class)
+    override fun ParsedAttestationRecord.verifyAndroidVersion() = teeEnforced.verifyAndroidVersion()
+
+    @Throws(AttestationException::class)
+    override fun ParsedAttestationRecord.verifyBootStateAndSystemImage() = teeEnforced.verifySystemLocked()
+
+    @Throws(AttestationException::class)
+    override fun ParsedAttestationRecord.verifyRollbackResistance() = teeEnforced.verifyRollbackResistance()
+}

--- a/android-attestation/src/main/kotlin/NougatHybridAttestationChecker.kt
+++ b/android-attestation/src/main/kotlin/NougatHybridAttestationChecker.kt
@@ -36,7 +36,7 @@ class NougatHybridAttestationChecker @JvmOverloads constructor(
         }
     }
 
-    override val trustAnchors = attestationConfiguration.hardwareAttestationTrustAnchors
+    override val trustAnchors = attestationConfiguration.softwareAttestationTrustAnchors
 
     @Throws(AttestationException::class)
     override fun ParsedAttestationRecord.verifyAndroidVersion(versionOverride: Int?, osPatchLevel: Int?) {

--- a/android-attestation/src/main/kotlin/NougatHybridAttestationChecker.kt
+++ b/android-attestation/src/main/kotlin/NougatHybridAttestationChecker.kt
@@ -12,39 +12,41 @@ import io.ktor.client.request.*
 import io.ktor.serialization.kotlinx.json.*
 import java.util.*
 
-class HardwareAttestationChecker @JvmOverloads constructor(
+class NougatHybridAttestationChecker @JvmOverloads constructor(
     attestationConfiguration: AndroidAttestationConfiguration,
     verifyChallenge: (expected: ByteArray, actual: ByteArray) -> Boolean = { expected, actual -> expected contentEquals actual }
 ) : AndroidAttestationChecker(attestationConfiguration, verifyChallenge) {
 
     init {
-        if (attestationConfiguration.disableHardwareAttestation) throw AttestationException("Hardware attestation is disabled!")
+        if (!attestationConfiguration.enableNougatAttestation) throw AttestationException("Hardware attestation is disabled!")
         if (attestationConfiguration.hardwareAttestationTrustAnchors.isEmpty()) throw AttestationException("No hardware attestation trust anchors configured")
     }
 
     @Throws(AttestationException::class)
     override fun ParsedAttestationRecord.verifySecurityLevel() {
         if (attestationConfiguration.requireStrongBox) {
-            if (attestationSecurityLevel != ParsedAttestationRecord.SecurityLevel.STRONG_BOX)
-                throw AttestationException("Attestation security level not StrongBox")
             if (keymasterSecurityLevel != ParsedAttestationRecord.SecurityLevel.STRONG_BOX)
                 throw AttestationException("Keymaster security level not StrongBox")
         } else {
-            if (attestationSecurityLevel == ParsedAttestationRecord.SecurityLevel.SOFTWARE)
-                throw AttestationException("Attestation security level software")
             if (keymasterSecurityLevel == ParsedAttestationRecord.SecurityLevel.SOFTWARE)
                 throw AttestationException("Keymaster security level software")
+        }
+        if (attestationSecurityLevel != ParsedAttestationRecord.SecurityLevel.SOFTWARE) {
+            throw AttestationException("Attestation security level not software")
         }
     }
 
     override val trustAnchors = attestationConfiguration.hardwareAttestationTrustAnchors
 
     @Throws(AttestationException::class)
-    override fun ParsedAttestationRecord.verifyAndroidVersion(versionOverride: Int?, osPatchLevel: Int?) =
-        teeEnforced.verifyAndroidVersion(versionOverride, osPatchLevel)
+    override fun ParsedAttestationRecord.verifyAndroidVersion(versionOverride: Int?, osPatchLevel: Int?) {
+        //impossible
+    }
 
     @Throws(AttestationException::class)
-    override fun ParsedAttestationRecord.verifyBootStateAndSystemImage() = teeEnforced.verifySystemLocked()
+    override fun ParsedAttestationRecord.verifyBootStateAndSystemImage() {
+        //impossible
+    }
 
     @Throws(AttestationException::class)
     override fun ParsedAttestationRecord.verifyRollbackResistance() = teeEnforced.verifyRollbackResistance()

--- a/android-attestation/src/main/kotlin/SoftwareAttestationChecker.kt
+++ b/android-attestation/src/main/kotlin/SoftwareAttestationChecker.kt
@@ -1,0 +1,53 @@
+package at.asitplus.attestation.android
+
+import at.asitplus.attestation.android.exceptions.AttestationException
+import com.google.android.attestation.ParsedAttestationRecord
+import io.ktor.client.*
+import io.ktor.client.call.*
+import io.ktor.client.engine.*
+import io.ktor.client.engine.cio.*
+import io.ktor.client.plugins.cache.*
+import io.ktor.client.plugins.contentnegotiation.*
+import io.ktor.client.request.*
+import io.ktor.serialization.kotlinx.json.*
+import java.security.PublicKey
+import java.util.*
+
+class SoftwareAttestationChecker @JvmOverloads constructor(
+    attestationConfiguration: AndroidAttestationConfiguration,
+    verifyChallenge: (expected: ByteArray, actual: ByteArray) -> Boolean = { expected, actual -> expected contentEquals actual }
+) : AndroidAttestationChecker(attestationConfiguration, verifyChallenge) {
+    init {
+        if (attestationConfiguration.softwareAttestationTrustAnchors.isEmpty()) throw AttestationException("No software attestation trust anchors configured")
+    }
+
+    companion object {
+        const val GOOGLE_SOFTWARE_EC_ROOT =
+            "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE7l1ex+HA220Dpn7mthvsTWpdamgu" +
+                    "D/9/SQ59dx9EIm29sa/6FsvHrcV30lacqrewLVQBXT5DKyqO107sSHVBpA=="
+        const val GOOGLE_SOFTWARE_RSA_ROOT =
+            "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCia63rbi5EYe/VDoLmt5TRdSMf" +
+                    "d5tjkWP/96r/C3JHTsAsQ+wzfNes7UA+jCigZtX3hwszl94OuE4TQKuvpSe/lWmg" +
+                    "MdsGUmX4RFlXYfC78hdLt0GAZMAoDo9Sd47b0ke2RekZyOmLw9vCkT/X11DEHTVm" +
+                    "+Vfkl5YLCazOkjWFmwIDAQAB"
+    }
+
+    @Throws(AttestationException::class)
+    override fun ParsedAttestationRecord.verifySecurityLevel() {
+        if (attestationSecurityLevel != ParsedAttestationRecord.SecurityLevel.SOFTWARE)
+            throw AttestationException("Attestation security level not software")
+        if (keymasterSecurityLevel != ParsedAttestationRecord.SecurityLevel.SOFTWARE)
+            throw AttestationException("Keymaster security level not software")
+    }
+
+    override val trustAnchors: Collection<PublicKey> = attestationConfiguration.softwareAttestationTrustAnchors
+
+    @Throws(AttestationException::class)
+    override fun ParsedAttestationRecord.verifyAndroidVersion() = softwareEnforced.verifyAndroidVersion()
+
+    @Throws(AttestationException::class)
+    override fun ParsedAttestationRecord.verifyBootStateAndSystemImage() = softwareEnforced.verifySystemLocked()
+
+    @Throws(AttestationException::class)
+    override fun ParsedAttestationRecord.verifyRollbackResistance() = softwareEnforced.verifyRollbackResistance()
+}

--- a/android-attestation/src/main/kotlin/SoftwareAttestationChecker.kt
+++ b/android-attestation/src/main/kotlin/SoftwareAttestationChecker.kt
@@ -18,6 +18,7 @@ class SoftwareAttestationChecker @JvmOverloads constructor(
     verifyChallenge: (expected: ByteArray, actual: ByteArray) -> Boolean = { expected, actual -> expected contentEquals actual }
 ) : AndroidAttestationChecker(attestationConfiguration, verifyChallenge) {
     init {
+        if (!attestationConfiguration.enableSoftwareAttestation) throw AttestationException("Software attestation is disabled!")
         if (attestationConfiguration.softwareAttestationTrustAnchors.isEmpty()) throw AttestationException("No software attestation trust anchors configured")
     }
 
@@ -43,10 +44,13 @@ class SoftwareAttestationChecker @JvmOverloads constructor(
     override val trustAnchors: Collection<PublicKey> = attestationConfiguration.softwareAttestationTrustAnchors
 
     @Throws(AttestationException::class)
-    override fun ParsedAttestationRecord.verifyAndroidVersion() = softwareEnforced.verifyAndroidVersion()
+    override fun ParsedAttestationRecord.verifyAndroidVersion(versionOverride: Int?, osPatchLevel: Int?) =
+        softwareEnforced.verifyAndroidVersion(versionOverride, osPatchLevel)
 
     @Throws(AttestationException::class)
-    override fun ParsedAttestationRecord.verifyBootStateAndSystemImage() = softwareEnforced.verifySystemLocked()
+    override fun ParsedAttestationRecord.verifyBootStateAndSystemImage() {
+        //impossible
+    }
 
     @Throws(AttestationException::class)
     override fun ParsedAttestationRecord.verifyRollbackResistance() = softwareEnforced.verifyRollbackResistance()

--- a/android-attestation/src/test/kotlin/AttestationTests.kt
+++ b/android-attestation/src/test/kotlin/AttestationTests.kt
@@ -23,45 +23,64 @@ class AttestationTests : FreeSpec() {
 
         "No HW attestation support" {
             AttestationData(
-                "Android Emulator",
-                challengeB64 = "RN9CjU7I5zpvCh7D3vi/aA==",
+                "Android Emulator RSA",
+                challengeB64 = "dRGIuJhE8j0t6lYbVfusgE17CWvGWXYpnTxcx0BZ87E=",
                 attestationProofB64 = listOf(
                     """
-                    MIICizCCAjKgAwIBAgIJAKIFntEOQ1tXMAoGCCqGSM49BAMCMIGYMQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEW
-                    MBQGA1UEBwwNTW91bnRhaW4gVmlldzEVMBMGA1UECgwMR29vZ2xlLCBJbmMuMRAwDgYDVQQLDAdBbmRyb2lkMTMwMQYDVQQDDCpB
-                    bmRyb2lkIEtleXN0b3JlIFNvZnR3YXJlIEF0dGVzdGF0aW9uIFJvb3QwHhcNMTYwMTExMDA0MzUwWhcNMzYwMTA2MDA0MzUwWjCB
-                    mDELMAkGA1UEBhMCVVMxEzARBgNVBAgMCkNhbGlmb3JuaWExFjAUBgNVBAcMDU1vdW50YWluIFZpZXcxFTATBgNVBAoMDEdvb2ds
-                    ZSwgSW5jLjEQMA4GA1UECwwHQW5kcm9pZDEzMDEGA1UEAwwqQW5kcm9pZCBLZXlzdG9yZSBTb2Z0d2FyZSBBdHRlc3RhdGlvbiBS
-                    b290MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE7l1ex+HA220Dpn7mthvsTWpdamguD/9/SQ59dx9EIm29sa/6FsvHrcV30lac
-                    qrewLVQBXT5DKyqO107sSHVBpKNjMGEwHQYDVR0OBBYEFMit6XdMRcOjzw0WEOR5QzohWjDPMB8GA1UdIwQYMBaAFMit6XdMRcOj
-                    zw0WEOR5QzohWjDPMA8GA1UdEwEB/wQFMAMBAf8wDgYDVR0PAQH/BAQDAgKEMAoGCCqGSM49BAMCA0cAMEQCIDUho++LNEYenNVg
-                    8x1YiSBq3KNlQfYNns6KGYxmSGB7AiBNC/NR2TB8fVvaNTQdqEcbY6WFZTytTySn502vQX3xvw==
+                    MIIE+zCCBGSgAwIBAgIBATANBgkqhkiG9w0BAQsFADB2MQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEVMBMGA1UE
+                    CgwMR29vZ2xlLCBJbmMuMRAwDgYDVQQLDAdBbmRyb2lkMSkwJwYDVQQDDCBBbmRyb2lkIFNvZnR3YXJlIEF0dGVzdGF0aW9uIEtl
+                    eTAeFw03MDAxMDEwMDAwMDBaFw02OTEyMzEyMzU5NTlaMB8xHTAbBgNVBAMMFEFuZHJvaWQgS2V5c3RvcmUgS2V5MIICIjANBgkq
+                    hkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAuOwpW9boeY2+tihDBAja17fOToCT2mdgUV9HC1xyN8y1pxUTEGGmWxaiVgy49ktl4Qoo
+                    MwOJd8rqcz/uyt4/okE6RvR4cpezPQ/h53eERDoasmxC6wERwg2MfA0Lqo7pY79gGmc2RXdMdFmMjSDJ0zQclhFJR5/zJhiqtN/R
+                    Y2nIV9B/urBgRVxwcAMBsQ59zu4SM6O1aomBqxM9+IuC5ylcxwRgWkqLgjIjo+haXuemfKsexXSI2AIu7sOm5GlMngwNVX1/2GBC
+                    mYMn+sAcRtoOJrGrrYaUpih8fi4oQnZirEkSaUErDdiDVkawhcNhVYZQ9puS75p011ZlJHg3Vlq3pgW7NeB0P8dDpSviqwvBgKyE
+                    HUf+a5ggKP+EWpJ+i62rOod7iNvSdpcQLDfbKmlo4nVAziM1aqafleV06CB1yABYe8SaSPpZKkPUK3HQPwsqZzjSHyZwUu6RSZRh
+                    iGsiYk2BwrhjWvLHRUmXbHP6HgIZtSOVhdrDUx3S/B2JJ2IxGZ6YCTnTaj+ajg0+XurkoWQfcAKzlm62pnReCjPlljky6kIl/tD/
+                    0k9aHall6M2QqJ29wgaGhDtFWISjbwifUHXH1wt9pBKCRack0zFJQ6i8CsRmPgsI7SXW6OZzwz5Jzu1stjFXRzTgcmNBkBHjkigU
+                    5SNAancp6+LMFdMCAwEAAaOCAWowggFmMAsGA1UdDwQEAwIHgDCCATQGCisGAQQB1nkCAREEggEkMIIBIAIBBAoBAAIBKQoBAAQg
+                    dRGIuJhE8j0t6lYbVfusgE17CWvGWXYpnTxcx0BZ87EEADCB66EIMQYCAQICAQOiAwIBAaMEAgIQAKUIMQYCAQICAQS/gUgFAgMB
+                    AAG/g3cCBQC/hT0IAgYBimuBRsi/hT4DAgEAv4VATDBKBCAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEBAAoBAgQg
+                    AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC/hUEFAgMBrbC/hUIFAgMDFRu/hUVEBEIwQDEaMBgEE2F0LmFzaXRwbHVz
+                    LmF0dHRlc3QCAQExIgQgNLl2LE1skNSEMZQMV73nMUJYsmQg7+Fqx/cnTw0zCtUwADAfBgNVHSMEGDAWgBTUDBAb+M1jufc5UrUO
+                    E1ym15mThjANBgkqhkiG9w0BAQsFAAOBgQCiCU5bJUV5sq+o8WEHspiM4A8WCtujZCC7gyHvemgn19qVIVRiU09Arae/dJnISvdh
+                    yUKNmMDHyozgLUyd4+YI1Vg1MR3O1Qm36esvHMeqeM/J6bon3ROsYZVvBMn6US4fx8mVM1Sz7rXqBu/JoomySVSSr5QnPDMl3V8z
+                    GGYohQ==
                     """,
                     """
-                    MIICeDCCAh6gAwIBAgICEAEwCgYIKoZIzj0EAwIwgZgxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQH
-                    DA1Nb3VudGFpbiBWaWV3MRUwEwYDVQQKDAxHb29nbGUsIEluYy4xEDAOBgNVBAsMB0FuZHJvaWQxMzAxBgNVBAMMKkFuZHJvaWQg
-                    S2V5c3RvcmUgU29mdHdhcmUgQXR0ZXN0YXRpb24gUm9vdDAeFw0xNjAxMTEwMDQ2MDlaFw0yNjAxMDgwMDQ2MDlaMIGIMQswCQYD
-                    VQQGEwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEVMBMGA1UECgwMR29vZ2xlLCBJbmMuMRAwDgYDVQQLDAdBbmRyb2lkMTswOQYD
-                    VQQDDDJBbmRyb2lkIEtleXN0b3JlIFNvZnR3YXJlIEF0dGVzdGF0aW9uIEludGVybWVkaWF0ZTBZMBMGByqGSM49AgEGCCqGSM49
-                    AwEHA0IABOueefhCY1msyyqRTImGzHCtkGaTgqlzJhP+rMv4ISdMIXSXSir+pblNf2bU4GUQZjW8U7ego6ZxWD7bPhGuEBSjZjBk
-                    MB0GA1UdDgQWBBQ//KzWGrE6noEguNUlHMVlux6RqTAfBgNVHSMEGDAWgBTIrel3TEXDo88NFhDkeUM6IVowzzASBgNVHRMBAf8E
-                    CDAGAQH/AgEAMA4GA1UdDwEB/wQEAwIChDAKBggqhkjOPQQDAgNIADBFAiBLipt77oK8wDOHri/AiZi03cONqycqRZ9pDMfDktQP
-                    jgIhAO7aAV229DLp1IQ7YkyUBO86fMy9Xvsiu+f+uXc/WT/7    
+                    MIICtjCCAh+gAwIBAgICEAAwDQYJKoZIhvcNAQELBQAwYzELMAkGA1UEBhMCVVMxEzARBgNVBAgMCkNhbGlmb3JuaWExFjAUBgNV
+                    BAcMDU1vdW50YWluIFZpZXcxFTATBgNVBAoMDEdvb2dsZSwgSW5jLjEQMA4GA1UECwwHQW5kcm9pZDAeFw0xNjAxMDQxMjQwNTNa
+                    Fw0zNTEyMzAxMjQwNTNaMHYxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRUwEwYDVQQKDAxHb29nbGUsIEluYy4x
+                    EDAOBgNVBAsMB0FuZHJvaWQxKTAnBgNVBAMMIEFuZHJvaWQgU29mdHdhcmUgQXR0ZXN0YXRpb24gS2V5MIGfMA0GCSqGSIb3DQEB
+                    AQUAA4GNADCBiQKBgQDAgyPcVogbuDAgafWwhWHG7r5/BeL1qEIEir6LR752/q7yXPKbKvoyABQWAUKZiaFfz8aBXrNjWDwv0vIL
+                    5Jgyg92BSxbX4YVBeuVKvClqOm21wAQIO2jFVsHwIzmRZBmGTVC3TUCuykhMdzVsiVoMJ1q/rEmdXX0jYvKcXgLocQIDAQABo2Yw
+                    ZDAdBgNVHQ4EFgQU1AwQG/jNY7n3OVK1DhNcpteZk4YwHwYDVR0jBBgwFoAUKfrxrMxN0kyWQCd1trDpMuUH/i4wEgYDVR0TAQH/
+                    BAgwBgEB/wIBADAOBgNVHQ8BAf8EBAMCAoQwDQYJKoZIhvcNAQELBQADgYEAni1IX4xnM9waha2Z11Aj6hTsQ7DhnerCI0YecrUZ
+                    3GAi5KVoMWwLVcTmnKItnzpPk2sxixZ4Fg2Iy9mLzICdhPDCJ+NrOPH90ecXcjFZNX2W88V/q52PlmEmT7K+gbsNSQQiis6f9/VC
+                    LiVE+iEHElqDtVWtGIL4QBSbnCBjBH8=  
                     """,
                     """
-                    MIICizCCAjKgAwIBAgIJAKIFntEOQ1tXMAoGCCqGSM49BAMCMIGYMQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEW
-                    MBQGA1UEBwwNTW91bnRhaW4gVmlldzEVMBMGA1UECgwMR29vZ2xlLCBJbmMuMRAwDgYDVQQLDAdBbmRyb2lkMTMwMQYDVQQDDCpB
-                    bmRyb2lkIEtleXN0b3JlIFNvZnR3YXJlIEF0dGVzdGF0aW9uIFJvb3QwHhcNMTYwMTExMDA0MzUwWhcNMzYwMTA2MDA0MzUwWjCB
-                    mDELMAkGA1UEBhMCVVMxEzARBgNVBAgMCkNhbGlmb3JuaWExFjAUBgNVBAcMDU1vdW50YWluIFZpZXcxFTATBgNVBAoMDEdvb2ds
-                    ZSwgSW5jLjEQMA4GA1UECwwHQW5kcm9pZDEzMDEGA1UEAwwqQW5kcm9pZCBLZXlzdG9yZSBTb2Z0d2FyZSBBdHRlc3RhdGlvbiBS
-                    b290MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE7l1ex+HA220Dpn7mthvsTWpdamguD/9/SQ59dx9EIm29sa/6FsvHrcV30lac
-                    qrewLVQBXT5DKyqO107sSHVBpKNjMGEwHQYDVR0OBBYEFMit6XdMRcOjzw0WEOR5QzohWjDPMB8GA1UdIwQYMBaAFMit6XdMRcOj
-                    zw0WEOR5QzohWjDPMA8GA1UdEwEB/wQFMAMBAf8wDgYDVR0PAQH/BAQDAgKEMAoGCCqGSM49BAMCA0cAMEQCIDUho++LNEYenNVg
-                    8x1YiSBq3KNlQfYNns6KGYxmSGB7AiBNC/NR2TB8fVvaNTQdqEcbY6WFZTytTySn502vQX3xvw==    
+                    MIICpzCCAhCgAwIBAgIJAP+U2d2fB8gMMA0GCSqGSIb3DQEBCwUAMGMxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlh
+                    MRYwFAYDVQQHDA1Nb3VudGFpbiBWaWV3MRUwEwYDVQQKDAxHb29nbGUsIEluYy4xEDAOBgNVBAsMB0FuZHJvaWQwHhcNMTYwMTA0
+                    MTIzMTA4WhcNMzUxMjMwMTIzMTA4WjBjMQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNTW91bnRh
+                    aW4gVmlldzEVMBMGA1UECgwMR29vZ2xlLCBJbmMuMRAwDgYDVQQLDAdBbmRyb2lkMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKB
+                    gQCia63rbi5EYe/VDoLmt5TRdSMfd5tjkWP/96r/C3JHTsAsQ+wzfNes7UA+jCigZtX3hwszl94OuE4TQKuvpSe/lWmgMdsGUmX4
+                    RFlXYfC78hdLt0GAZMAoDo9Sd47b0ke2RekZyOmLw9vCkT/X11DEHTVm+Vfkl5YLCazOkjWFmwIDAQABo2MwYTAdBgNVHQ4EFgQU
+                    KfrxrMxN0kyWQCd1trDpMuUH/i4wHwYDVR0jBBgwFoAUKfrxrMxN0kyWQCd1trDpMuUH/i4wDwYDVR0TAQH/BAUwAwEB/zAOBgNV
+                    HQ8BAf8EBAMCAoQwDQYJKoZIhvcNAQELBQADgYEAT3LzNlmNDsG5dFsxWfbwjSVJMJ6jHBwp0kUtILlNX2S06IDHeHqcOd6os/W/
+                    L3BfRxBcxebrTQaZYdKumgf/93y4q+ucDyQHXrF/unlx/U1bnt8Uqf7f7XzAiF343ZtkMlbVNZriE/mPzsF83O+kqrJVw4OpLvtc
+                    9mL1J1IXvmM=    
                     """
                 ),
-                isoDate = "2023-04-18T00:00:00Z",
-                pubKeyB64 = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEgQC2Fo5nb6dlnJh2h4tg0vnJmjPN8x2t+tlwbZEjWO6uJWlqu5uTPFkYKzgpxF6HVoOFYWwPFBZgB4ktwU3ysw=="
+                isoDate = "2023-09-06T17:19:03.443Z",
+                pubKeyB64 = "MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAuOwpW9boeY2+tihDBAja17fOToCT2mdgUV9HC1xyN8y1" +
+                        "pxUTEGGmWxaiVgy49ktl4QooMwOJd8rqcz/uyt4/okE6RvR4cpezPQ/h53eERDoasmxC6wERwg2MfA0Lqo7pY79gGmc2" +
+                        "RXdMdFmMjSDJ0zQclhFJR5/zJhiqtN/RY2nIV9B/urBgRVxwcAMBsQ59zu4SM6O1aomBqxM9+IuC5ylcxwRgWkqLgjIj" +
+                        "o+haXuemfKsexXSI2AIu7sOm5GlMngwNVX1/2GBCmYMn+sAcRtoOJrGrrYaUpih8fi4oQnZirEkSaUErDdiDVkawhcNh" +
+                        "VYZQ9puS75p011ZlJHg3Vlq3pgW7NeB0P8dDpSviqwvBgKyEHUf+a5ggKP+EWpJ+i62rOod7iNvSdpcQLDfbKmlo4nVA" +
+                        "ziM1aqafleV06CB1yABYe8SaSPpZKkPUK3HQPwsqZzjSHyZwUu6RSZRhiGsiYk2BwrhjWvLHRUmXbHP6HgIZtSOVhdrD" +
+                        "Ux3S/B2JJ2IxGZ6YCTnTaj+ajg0+XurkoWQfcAKzlm62pnReCjPlljky6kIl/tD/0k9aHall6M2QqJ29wgaGhDtFWISj" +
+                        "bwifUHXH1wt9pBKCRack0zFJQ6i8CsRmPgsI7SXW6OZzwz5Jzu1stjFXRzTgcmNBkBHjkigU5SNAancp6+LMFdMCAwEA" +
+                        "AQ=="
             ).apply {
                 shouldThrow<CertificateInvalidException> {
                     attestationService().verifyAttestation(

--- a/android-attestation/src/test/kotlin/AttestationTests.kt
+++ b/android-attestation/src/test/kotlin/AttestationTests.kt
@@ -402,11 +402,15 @@ fun attestationService(
     requireStrongBox: Boolean = false,
     unlockedBootloaderAllowed: Boolean = false,
     requireRollbackResistance: Boolean = false
-) = AndroidAttestationChecker(
+) = HardwareAttestationChecker(
     AndroidAttestationConfiguration(
-        packageName = androidPackageName,
-        signatureDigests = androidAppSignatureDigest,
-        appVersion = androidAppVersion,
+        listOf(
+            AndroidAttestationConfiguration.AppData(
+                packageName = androidPackageName,
+                signatureDigests = androidAppSignatureDigest,
+                appVersion = androidAppVersion
+            )
+        ),
         androidVersion = androidVersion,
         patchLevel = androidPatchLevel,
         requireStrongBox = requireStrongBox,

--- a/android-attestation/src/test/kotlin/AttestationTests.kt
+++ b/android-attestation/src/test/kotlin/AttestationTests.kt
@@ -634,7 +634,7 @@ fun attestationService(
         androidVersion = androidVersion,
         patchLevel = androidPatchLevel,
         requireStrongBox = requireStrongBox,
-        bootloaderUnlockAllowed = unlockedBootloaderAllowed,
+        allowBootloaderUnlock = unlockedBootloaderAllowed,
         requireRollbackResistance = requireRollbackResistance
     )
 )

--- a/android-attestation/src/test/kotlin/FakeAttestationTests.kt
+++ b/android-attestation/src/test/kotlin/FakeAttestationTests.kt
@@ -36,7 +36,7 @@ class FakeAttestationTests : FreeSpec({
                 androidVersion = androidVersion,
                 patchLevel = patchLevel,
                 requireStrongBox = false,
-                bootloaderUnlockAllowed = false,
+                allowBootloaderUnlock = false,
                 ignoreLeafValidity = false,
                 hardwareAttestationTrustAnchors = setOf(attestationProof.last().publicKey)
             )
@@ -132,7 +132,7 @@ class FakeAttestationTests : FreeSpec({
                     androidVersion = androidVersion,
                     patchLevel = patchLevel,
                     requireStrongBox = false,
-                    bootloaderUnlockAllowed = false,
+                    allowBootloaderUnlock = false,
                     ignoreLeafValidity = false
                 )
             )

--- a/android-attestation/src/test/kotlin/FakeAttestationTests.kt
+++ b/android-attestation/src/test/kotlin/FakeAttestationTests.kt
@@ -38,7 +38,7 @@ class FakeAttestationTests : FreeSpec({
                 requireStrongBox = false,
                 bootloaderUnlockAllowed = false,
                 ignoreLeafValidity = false,
-                hardwareAttestationTrustAnchors = listOf(attestationProof.last().publicKey)
+                hardwareAttestationTrustAnchors = setOf(attestationProof.last().publicKey)
             )
         )
 
@@ -105,7 +105,7 @@ class FakeAttestationTests : FreeSpec({
         )
 
         "should work when the fake cert is configured as trust anchor" {
-            val record = checker.verifyAttestation(
+            checker.verifyAttestation(
                 certificates = attestationProof,
                 expectedChallenge = challenge
             )

--- a/android-attestation/src/test/kotlin/FakeAttestationTests.kt
+++ b/android-attestation/src/test/kotlin/FakeAttestationTests.kt
@@ -27,17 +27,18 @@ class FakeAttestationTests : FreeSpec({
             androidPatchLevel = patchLevel.asSingleInt
         )
 
-        val checker = AndroidAttestationChecker(
+        val checker = HardwareAttestationChecker(
             AndroidAttestationConfiguration(
-                packageName = packageName,
-                signatureDigests = listOf(signatureDigest),
-                appVersion = appVersion,
+                listOf(AndroidAttestationConfiguration.AppData(
+                    packageName = packageName,
+                    signatureDigests = listOf(signatureDigest),
+                    appVersion = appVersion)),
                 androidVersion = androidVersion,
                 patchLevel = patchLevel,
                 requireStrongBox = false,
                 bootloaderUnlockAllowed = false,
                 ignoreLeafValidity = false,
-                trustAnchors = listOf(attestationProof.last().publicKey)
+                hardwareAttestationTrustAnchors = listOf(attestationProof.last().publicKey)
             )
         )
 
@@ -119,11 +120,15 @@ class FakeAttestationTests : FreeSpec({
         }
 
         "and the fake attestation must not verify against the google root key" {
-            val trustedChecker = AndroidAttestationChecker(
+            val trustedChecker = HardwareAttestationChecker(
                 AndroidAttestationConfiguration(
-                    packageName = packageName,
-                    signatureDigests = listOf(signatureDigest),
-                    appVersion = appVersion,
+                    listOf(
+                        AndroidAttestationConfiguration.AppData(
+                            packageName = packageName,
+                            signatureDigests = listOf(signatureDigest),
+                            appVersion = appVersion,
+                        )
+                    ),
                     androidVersion = androidVersion,
                     patchLevel = patchLevel,
                     requireStrongBox = false,

--- a/android-attestation/src/test/kotlin/data/AttestationData.kt
+++ b/android-attestation/src/test/kotlin/data/AttestationData.kt
@@ -1,5 +1,6 @@
 package at.asitplus.attestation.data
 
+import com.google.android.attestation.ParsedAttestationRecord
 import java.security.KeyFactory
 import java.security.PublicKey
 import java.security.cert.CertificateFactory
@@ -37,3 +38,7 @@ val AttestationData.attestationCertChain: List<X509Certificate>
             .generateCertificate(mimeDecoder.decode(it).inputStream()) as X509Certificate
 
     }
+val AttestationData.androidAttestationRecord: ParsedAttestationRecord?
+    get() = if (attestationProofB64.size > 2)
+        ParsedAttestationRecord.createParsedAttestationRecord(attestationCertChain)
+    else null

--- a/attestation-diag/build.gradle.kts
+++ b/attestation-diag/build.gradle.kts
@@ -1,0 +1,22 @@
+
+group = "at.asitplus"
+version = "0.0.1"
+
+plugins {
+    kotlin("jvm")
+    application
+    id("at.asitplus.gradle.conventions")
+    id("com.github.johnrengelman.shadow")
+}
+
+kotlin{
+    jvmToolchain(11)
+}
+application {
+    mainClass.set("at.asitplus.attestation.android.DiagKt")
+}
+
+dependencies {
+    implementation(project(":android-attestation"))
+    implementation("com.google.code.gson:gson:2.10.1")
+}

--- a/attestation-diag/src/main/kotlin/Diag.kt
+++ b/attestation-diag/src/main/kotlin/Diag.kt
@@ -1,0 +1,80 @@
+package at.asitplus.attestation.android
+
+import com.google.android.attestation.ParsedAttestationRecord
+import java.io.File
+import java.security.PublicKey
+import java.security.cert.X509Certificate
+import com.google.gson.Gson
+import com.google.gson.GsonBuilder
+import com.google.gson.JsonPrimitive
+import com.google.gson.JsonNull
+import com.google.gson.JsonSerializer
+
+fun main(args: Array<String>) {
+
+    if (args.isEmpty()) {
+        System.err.println("Certificat neither specified in a file (-f <path to PEM/Base64 cert>) nor as parameter <Base64 cert>!")
+        System.exit(1)
+    }
+    val certB64 = if (args[0] == "-f") java.io.File(args[1]).readText() else args[0]
+
+    val full = args.last() == "-v"
+
+
+    @OptIn(ExperimentalStdlibApi::class, kotlin.io.encoding.ExperimentalEncodingApi::class)
+    val gson: Gson = GsonBuilder().apply {
+
+        registerTypeAdapter(ByteArray::class.java,
+            JsonSerializer<ByteArray> { src, _, _ ->
+                JsonPrimitive(src?.toHexString(HexFormat.UpperCase))
+            })
+        registerTypeAdapter(java.security.PublicKey::class.java, JsonSerializer<java.security.PublicKey> { src, _, _ ->
+            com.google.gson.JsonObject().apply {
+                add("algorithm", JsonPrimitive(src.algorithm))
+                add("format", JsonPrimitive(src.format))
+                add("encoded", JsonPrimitive(src.encoded.toHexString(HexFormat.UpperCase)))
+            }
+        })
+        registerTypeAdapter(
+            java.util.Optional::class.java,
+            JsonSerializer<java.util.Optional<*>> { src, _, ctx ->
+                if (src == null || src.isEmpty) {
+                    if (!full) null else JsonNull()
+                } else ctx.serialize(src.get())
+            })
+        registerTypeAdapter(
+            java.security.cert.Certificate::class.java,
+            JsonSerializer<java.security.cert.Certificate> { src, _, _ ->
+                JsonPrimitive(src?.let { kotlin.io.encoding.Base64.encode(it.encoded) })
+            })
+        registerTypeAdapter(java.time.Instant::class.java, JsonSerializer<java.time.Instant> { src, _, _ ->
+            JsonPrimitive(src?.toString())
+        })
+        if (!full) registerTypeAdapter(
+            com.google.common.collect.ImmutableSet::class.java,
+            JsonSerializer<com.google.common.collect.ImmutableSet<*>> { src, _, ctx ->
+                if (src == null || src.isEmpty()) null
+                else ctx.serialize(src)
+            })
+
+        disableJdkUnsafe()
+        if (full) serializeNulls()
+        setPrettyPrinting()
+    }.create()
+
+
+    println(
+        gson.toJson(
+            ParsedAttestationRecord.createParsedAttestationRecord(
+                listOf(
+                    java.security.cert.CertificateFactory.getInstance(
+                        "X.509"
+                    ).generateCertificate(
+                        java.util.Base64.getMimeDecoder()
+                            .decode(certB64.replace("\\n", "").replace("\\r", "").replace(" ", "")).inputStream()
+                    ) as X509Certificate
+                )
+            )
+        )
+    )
+}

--- a/attestation-diag/src/main/kotlin/Diag.kt
+++ b/attestation-diag/src/main/kotlin/Diag.kt
@@ -39,7 +39,7 @@ fun main(args: Array<String>) {
             java.util.Optional::class.java,
             JsonSerializer<java.util.Optional<*>> { src, _, ctx ->
                 if (src == null || src.isEmpty) {
-                    if (!full) null else JsonNull()
+                    if (!full) null else JsonNull.INSTANCE
                 } else ctx.serialize(src.get())
             })
         registerTypeAdapter(

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,3 @@
-plugins {  id("at.asitplus.gradle.conventions") version "1.9.10+20230828" }
+plugins {  id("at.asitplus.gradle.conventions") version "1.9.10+20230908" }
 
 group = "at.asitplus"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,3 @@
-plugins {  id("at.asitplus.gradle.conventions") version "1.9.10+20230908" }
+plugins {  id("at.asitplus.gradle.conventions") version "1.9.10+20230911" }
 
 group = "at.asitplus"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,7 +6,6 @@ pluginManagement {
             url = uri("https://raw.githubusercontent.com/a-sit-plus/gradle-conventions-plugin/mvn/repo")
             name = "aspConventions"
         }
-        maven("https://maven.pkg.jetbrains.space/kotlin/p/dokka/dev")
         mavenCentral()
         gradlePluginPortal()
     }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,3 +13,4 @@ pluginManagement {
 }
 
 include("android-attestation")
+include("attestation-diag")


### PR DESCRIPTION
* configure multiple apps (package, version, …)
* Three three flavours of attestation:
   * Hardware attestation
   * Hybrid Attestation (for devices originally released with Android 7)
   * Software Attestation (for potatoes)
* Builder pattern for configuration
* Diagnostics app (runnable jar in separate module) to pretty-print attestation records from certificates)
* Dependency Updates
   * Ktor 2.3.4
   * Bouncy Castle 1.76